### PR TITLE
Add Version Number to Database AB#189 - config file implementation

### DIFF
--- a/src/AutoBugTracker.py
+++ b/src/AutoBugTracker.py
@@ -104,9 +104,9 @@ class AutoBugTracker(object):
         parsedError = str(traceback).split("\n")
         print(traceback)
         if str(parsedError[0]).__contains__("Traceback (most recent call last)"):
-            title = "location -- " + str(parsedError[1]) + " ver. " + str(versionNum)
+            title = "location -- " + str(parsedError[1]) + "   -ver " + str(versionNum)
         else:
-            title = "location -- " + str(parsedError[0]) + " ver. " + str(versionNum)
+            title = "location -- " + str(parsedError[0]) + "   -ver " + str(versionNum)
         bugReport = bugRecordDTO.BugRecordDTO(title=title,
                                               tracebackInfo=traceback, resolved=False, version=versionNum)
         githubIssueToSend = githubIssue.GithubIssue(title=title, body=traceback, labels="bug")

--- a/src/AutoBugTracker.py
+++ b/src/AutoBugTracker.py
@@ -104,9 +104,9 @@ class AutoBugTracker(object):
         parsedError = str(traceback).split("\n")
         print(traceback)
         if str(parsedError[0]).__contains__("Traceback (most recent call last)"):
-            title = "location -- " + str(parsedError[1])
+            title = "location -- " + str(parsedError[1]) + " ver. " + str(versionNum)
         else:
-            title = "location -- " + str(parsedError[0])
+            title = "location -- " + str(parsedError[0]) + " ver. " + str(versionNum)
         bugReport = bugRecordDTO.BugRecordDTO(title=title,
                                               tracebackInfo=traceback, resolved=False, version=versionNum)
         githubIssueToSend = githubIssue.GithubIssue(title=title, body=traceback, labels="bug")

--- a/src/AutoBugTracker.py
+++ b/src/AutoBugTracker.py
@@ -99,6 +99,7 @@ class AutoBugTracker(object):
         """
         issues bug report according to config file
         """
+        versionNum = self.configOptions.getConfig(key='version_num')
         traceback = request.data.decode("utf-8")
         parsedError = str(traceback).split("\n")
         print(traceback)
@@ -107,7 +108,7 @@ class AutoBugTracker(object):
         else:
             title = "location -- " + str(parsedError[0])
         bugReport = bugRecordDTO.BugRecordDTO(title=title,
-                                              tracebackInfo=traceback, resolved=False)
+                                              tracebackInfo=traceback, resolved=False, version=versionNum)
         githubIssueToSend = githubIssue.GithubIssue(title=title, body=traceback, labels="bug")
         self.database.list_insert(bugRecordDTO=bugReport)
         if self.configOptions.getConfig(key="send_github_issue") and self.configOptions.getConfig(key="github_integration"):

--- a/src/BugRecordDTO.py
+++ b/src/BugRecordDTO.py
@@ -1,9 +1,10 @@
 class BugRecordDTO:
-    def __init__(self, title=None, tracebackInfo=None, resolved=None):
+    def __init__(self, title=None, tracebackInfo=None, resolved=None, version=None):
         self.title = title
         self.tracebackInfo = tracebackInfo
         self.resolved = resolved
+        self.version = version
 
     def __repr__(self):
         return "Bug Title: " + self.title + "\n" + "Bug TracebackInfo: " + str(
-            self.tracebackInfo) + "\n" + "Bug Resolved: " + str(self.resolved)
+            self.tracebackInfo) + "\n" + "Bug Resolved: " + str(self.resolved) + "\n" + "Version: " + str(self.version)

--- a/src/DBConfig.py
+++ b/src/DBConfig.py
@@ -3,7 +3,7 @@ import os
 
 
 def config(section):
-    filename = os.path.abspath('../../resource/Database.ini')
+    filename = os.path.abspath('../resource/Database.ini')
     parser = ConfigParser()
     parser.read(filename)
 

--- a/src/DatabaseScript.py
+++ b/src/DatabaseScript.py
@@ -68,6 +68,7 @@ class Database:
                         Title text NULL,
                         Traceback_info text NULL,
                         Resolved BOOL NULL,
+                        version text NULL,
                         PRIMARY KEY (Title)
                         ); """)
             # execute the sql query
@@ -93,12 +94,13 @@ class Database:
             insert_query = (" INSERT INTO " + self.bug_table_name + """(
                             Title,  
                             Traceback_info, 
-                            Resolved) 
-                            VALUES (%s, %s, %s) """)
+                            Resolved,
+                            Version,) 
+                            VALUES (%s, %s, %s, %s); """)
 
             cursor.execute(insert_query,
                            (bugRecordDTO.title,
-                            bugRecordDTO.tracebackInfo, bugRecordDTO.resolved))
+                            bugRecordDTO.tracebackInfo, bugRecordDTO.resolved, bugRecordDTO.version))
             conn.commit()
         except (Exception, psycopg2.Error) as e:
             self.debugLogFile.writeToFile("Could not insert record into table " + str(e))

--- a/src/DatabaseScript.py
+++ b/src/DatabaseScript.py
@@ -68,7 +68,7 @@ class Database:
                         Title text NULL,
                         Traceback_info text NULL,
                         Resolved BOOL NULL,
-                        version text NULL,
+                        Version text NULL,
                         PRIMARY KEY (Title)
                         ); """)
             # execute the sql query
@@ -95,7 +95,7 @@ class Database:
                             Title,  
                             Traceback_info, 
                             Resolved,
-                            Version,) 
+                            Version) 
                             VALUES (%s, %s, %s, %s); """)
 
             cursor.execute(insert_query,

--- a/src/ReadConfig.py
+++ b/src/ReadConfig.py
@@ -34,7 +34,7 @@ class readConfig:
             rec = dict(first="John", last="Doe", email="johndoe@doe.com",
                        create_debug_log=True, overwrite_previous_entry=False, log_file="log.txt",
                        github_integration=False, github_access_token="",
-                       github_repo_name="", send_email=True, send_github_issue=False)
+                       github_repo_name="", send_email=True, send_github_issue=False, version_num="0.0")
             json.dump(rec, fp=open(self.configPath, 'w'), indent=4)
 
     def showConfig(self):
@@ -51,7 +51,7 @@ class readConfig:
         provided. If invalid key provided returns None.
         *CURRENT VALID KEYS: name,email,overwrite_previous_entry,create_debug_log,
                              log_file, github_integration, github_access_token,
-                             github_repo_name
+                             github_repo_name, version_num
         param: key:config file Key
         return: config key value
         """


### PR DESCRIPTION
AB#189

- Version number of program being run by AutoBugTracker is grabbed via a config file option.
- Version number is added as a new column to the database, and is placed into the title to allow duplicates of the same bug, as long as the version numbers are different.

**Significant changes made:**
ReadConfig.py
Adds new config file option `version_num` defaulted to 0.0

AutoBugTracker.py
Grabs version number through `getConfig` to be passed into the title of the bug report


